### PR TITLE
画像処理サーバーに画像を送信して処理できるようにした。

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ tensorflow
 flake8
 black
 Flask
+Pillow

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -1,0 +1,38 @@
+from flask import Flask, request, jsonify, after_this_request, render_template
+import base64
+from PIL import Image
+from io import BytesIO
+import numpy as np
+
+template_dir = "/sake/frontend/src/html"
+static_dir = "/sake/frontend/src/js"
+app = Flask(__name__, template_folder=template_dir, static_folder=static_dir)
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/imageProcessing", methods=["POST"])
+def image_detection():
+    @after_this_request
+    def add_header(response):
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        return response
+
+    enc_data = request.form["img"]
+    dec_data = base64.b64decode(enc_data.split(",")[1])
+    img_pil = Image.open(BytesIO(dec_data))
+    img_np = np.array(img_pil)
+
+    print(img_np)
+    # img_pil.save("image.png", quality=95)
+
+    # これ以降に画像処理を書いていく
+
+    return jsonify(out1=1, out2="text")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000, debug=True)

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -4,16 +4,19 @@ from PIL import Image
 from io import BytesIO
 import numpy as np
 
+# Flaskの設定
 template_dir = "/sake/frontend/src/html"
 static_dir = "/sake/frontend/src/js"
 app = Flask(__name__, template_folder=template_dir, static_folder=static_dir)
 
 
+# ルートにリクエスト(/)があった時の処理 ※Reactで実装する場合は必要ない
 @app.route("/")
 def index():
     return render_template("index.html")
 
 
+# 画像処理のリクエスト(/imageProcessing)があった時の処理
 @app.route("/imageProcessing", methods=["POST"])
 def image_detection():
     @after_this_request
@@ -21,15 +24,15 @@ def image_detection():
         response.headers["Access-Control-Allow-Origin"] = "*"
         return response
 
+    # 送信された画像をデコードしてnumpyに変換
     enc_data = request.form["img"]
     dec_data = base64.b64decode(enc_data.split(",")[1])
     img_pil = Image.open(BytesIO(dec_data))
     img_np = np.array(img_pil)
 
+    # これ以降に画像処理を書いていく
     print(img_np)
     # img_pil.save("image.png", quality=95)
-
-    # これ以降に画像処理を書いていく
 
     return jsonify(out1=1, out2="text")
 

--- a/frontend/src/html/index.html
+++ b/frontend/src/html/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Camera Test</title>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 </head>
 
 <body>
@@ -19,10 +20,11 @@
     </form>
 
     <script type="text/javascript" src="../js/controlCamera.js"></script>
+    <!-- <script src="{{url_for('static', filename='controlCamera.js')}}"></script> -->
+
     <script>
         controlCamera("camera", "canvas", "shutter");
         uploadImageToServer("camera", "canvas", "upload");
-        console.log("success !!");
     </script>
 
 </body>

--- a/frontend/src/js/controlCamera.js
+++ b/frontend/src/js/controlCamera.js
@@ -59,23 +59,43 @@ function controlCamera(videoId, canvasId, shutterButtonId) {
  * uploadボタンを押すとサーバー画像を送信する
  * @param  {String} videoId           カメラが映し出す映像を表示する<video>タグのid
  * @param  {String} canvasId          撮影した結果を表示する<canvas>タグのid
- * @param  {String} uploadButtonId      撮影した画像を送信するボタンのid
- * @return {any}                      画像の処理結果を出力(予定)
+ * @param  {String} uploadButtonId    撮影した画像を送信するボタンのid
+ * @return {void}
  */
 
 function uploadImageToServer(videoId, canvasId, uploadButtonId) {
   /**
    *  送信ボタンが押された時<canvas>の画像をbase64に変換
    */
-  let imageBase64;
   document.querySelector(`#${uploadButtonId}`).addEventListener("click", () => {
     const video = document.querySelector(`#${videoId}`);
     const canvas = document.querySelector(`#${canvasId}`);
-    imageBase64 = canvas.toDataURL("image/png");
+    const imageBase64 = canvas.toDataURL("image/png");
     video.style.display = "none"; // <video>タグを非表示
-    console.log(`image: ${imageBase64}`);
-  });
 
-  // これ以降にアップロードする処理を書いていく
-  console.log("image upload.");
+    // console.log(`image: ${imageBase64}`);
+    const formData = new FormData();
+    formData.append("img", imageBase64);
+
+    $.ajax({
+      // 画像処理サーバーに返す場合
+      url: "http://127.0.0.1:8000/imageProcessing",
+      type: "POST",
+      mode: "no-cors",
+      data: formData,
+      contentType: false,
+      processData: false,
+      dataType: "json",
+      success: (json) => {
+        // 非同期で通信成功時に読み出される [200 OK 時]
+        // out*はサーバー（python）からの戻り値
+        console.log(`Success ${json.out1}`);
+        console.log(`Success ${json.out2}`);
+      },
+      error: (errorThrown) => {
+        //  非同期で通信失敗時に読み出される
+        console.error(`Error : ${errorThrown}`);
+      },
+    });
+  });
 }

--- a/frontend/src/js/controlCamera.js
+++ b/frontend/src/js/controlCamera.js
@@ -11,7 +11,7 @@ function controlCamera(videoId, canvasId, shutterButtonId) {
     const video = document.querySelector(`#${videoId}`);
     const canvas = document.getElementById(canvasId);
 
-    /* カメラの設定 */
+    // カメラの設定
     const constraints = {
       audio: false,
       video: {
@@ -22,9 +22,7 @@ function controlCamera(videoId, canvasId, shutterButtonId) {
       },
     };
 
-    /**
-     *  カメラを<video>と同期
-     */
+    // カメラを<video>と同期
     navigator.mediaDevices
       .getUserMedia(constraints)
       .then((stream) => {
@@ -37,9 +35,7 @@ function controlCamera(videoId, canvasId, shutterButtonId) {
         console.error(`${err.name}: ${err.message}`);
       });
 
-    /**
-     *  撮影ボタン(ボタンが押された時の<video>の1フレームを<canvas>に表示)
-     */
+    // 撮影ボタンが押されたときのイベント処理（<video>の1フレームを<canvas>に表示）
     document
       .querySelector(`#${shutterButtonId}`)
       .addEventListener("click", () => {
@@ -64,19 +60,18 @@ function controlCamera(videoId, canvasId, shutterButtonId) {
  */
 
 function uploadImageToServer(videoId, canvasId, uploadButtonId) {
-  /**
-   *  送信ボタンが押された時<canvas>の画像をbase64に変換
-   */
+  // 送信ボタンが押されたときのイベント処理（<canvasの画像を送信できる形式に変換して、画像処理サーバーに送信>）
   document.querySelector(`#${uploadButtonId}`).addEventListener("click", () => {
+    // 画像をbase64に変換
     const video = document.querySelector(`#${videoId}`);
     const canvas = document.querySelector(`#${canvasId}`);
     const imageBase64 = canvas.toDataURL("image/png");
     video.style.display = "none"; // <video>タグを非表示
-
-    // console.log(`image: ${imageBase64}`);
     const formData = new FormData();
     formData.append("img", imageBase64);
+    // console.log(`image: ${imageBase64}`);
 
+    // 画像をPOST方式で送信 url：http://127.0.0.1:8000/imageProcessing
     $.ajax({
       // 画像処理サーバーに返す場合
       url: "http://127.0.0.1:8000/imageProcessing",


### PR DESCRIPTION
## 🔨 Details of Changes
<!-- 変更内容について記載する -->
- 画像処理サーバーに画像を送信して、処理できるように機能を実装した。
- 画像を送信する際にjQueryのAjaxを使用した。
- バックエンド側の処理を行うプログラムは`backend/src/app.py`にあります。

## 📸 Screenshot
<!-- 必要な場合はスクリーンショットを追加する -->
送信ボタンを押すとFlaskのプログラムを実行したのターミナル上で以下のように表示されます。
![画像を送信](https://user-images.githubusercontent.com/38716288/131644125-6dffcb79-0ff6-417f-bd16-2b15e31a3c69.jpg)

## ✅ Resolved Issues
<!-- 解決する Issues を記載する -->
- close #37 

## 🤝 Related Issues
<!-- 関連する Issues を記載する -->
- #38 
- #48 
