### PR TITLE
カメラの操作がスマホのブラウザ上で正しく動作しない不具合を修正

### DIFF
--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -43,4 +43,8 @@ def result():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=8000, debug=True)
+    app.run(
+        host="0.0.0.0",
+        port=8000,
+        debug=True,
+    )

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -43,8 +43,4 @@ def result():
 
 
 if __name__ == "__main__":
-    app.run(
-        host="0.0.0.0",
-        port=8000,
-        debug=True,
-    )
+    app.run(host="0.0.0.0", port=8000, debug=True)

--- a/frontend/src/html/index.html
+++ b/frontend/src/html/index.html
@@ -10,7 +10,7 @@
 
     <h1>トップページ</h1>
 
-    <video id="camera" width="100%" height="10%"></video>
+    <video id="camera" playsinline autoplay muted loop width="100%"></video>
     <canvas id="canvas" hidden></canvas>
 
     <form action="/previewImage" method="POST">

--- a/frontend/src/js/controlCamera.js
+++ b/frontend/src/js/controlCamera.js
@@ -47,7 +47,7 @@ function controlCamera(videoId, canvasId, shutterButtonId, formImageId) {
       canvas.setAttribute("width", w.toString());
       canvas.setAttribute("height", h.toString());
       canvasContext.drawImage(video, 0, 0, w, h);
-      formImage.value = canvas.toDataURL("image/jpeg", 0.75); // 0.75だと上手くいっ
+      formImage.value = canvas.toDataURL("image/jpeg", 0.75);
     });
   };
 }

--- a/frontend/src/js/controlCamera.js
+++ b/frontend/src/js/controlCamera.js
@@ -41,13 +41,13 @@ function controlCamera(videoId, canvasId, shutterButtonId, formImageId) {
     // 撮影ボタンが押されたときのイベント処理（<video>の1フレームを<canvas>に表示）
     document.getElementById(shutterButtonId).addEventListener("click", () => {
       const canvasContext = canvas.getContext("2d");
-      const w = video.offsetWidth / 10;
-      const h = video.offsetHeight / 10;
+      const w = video.offsetWidth;
+      const h = video.offsetHeight;
 
       canvas.setAttribute("width", w.toString());
       canvas.setAttribute("height", h.toString());
       canvasContext.drawImage(video, 0, 0, w, h);
-      formImage.value = canvas.toDataURL("image/png");
+      formImage.value = canvas.toDataURL("image/jpeg", 0.75); // 0.75だと上手くいっ
     });
   };
 }

--- a/frontend/src/js/controlCamera.js
+++ b/frontend/src/js/controlCamera.js
@@ -41,8 +41,9 @@ function controlCamera(videoId, canvasId, shutterButtonId, formImageId) {
     // 撮影ボタンが押されたときのイベント処理（<video>の1フレームを<canvas>に表示）
     document.getElementById(shutterButtonId).addEventListener("click", () => {
       const canvasContext = canvas.getContext("2d");
-      const w = video.offsetWidth;
-      const h = video.offsetHeight;
+      const w = video.offsetWidth / 10;
+      const h = video.offsetHeight / 10;
+
       canvas.setAttribute("width", w.toString());
       canvas.setAttribute("height", h.toString());
       canvasContext.drawImage(video, 0, 0, w, h);


### PR DESCRIPTION
## 🔨 Details of Changes
<!-- 変更内容について記載する -->
- 送信する画像の解像度をカメラで撮影した画像の10分の1に縮小して送信するように変更
- スマホ上で正しく動作するようにvideoタグの属性を追加
- ローカル環境ではSSL認証の都合上、https接続できないのでうまくいかないが、クラウドにデプロイした場合は正しく動作しています。

## 📸 Screenshot
<!-- 必要な場合はスクリーンショットを追加する -->

## ✅ Resolved Issues
<!-- 解決する Issues を記載する -->
- close #63 

## 🤝 Related Issues
<!-- 関連する Issues を記載する -->
- #63 
- #72
